### PR TITLE
[interrop] add json serializer

### DIFF
--- a/src/envoy/core.clj
+++ b/src/envoy/core.clj
@@ -27,7 +27,7 @@
 (defn- fromBase64 [s]
   (String. (DatatypeConverter/parseBase64Binary s)))
 
-(defn- read-values 
+(defn- read-values
   ([resp]
    (read-values resp true))
   ([{:keys [body]} to-keys?]
@@ -37,7 +37,7 @@
            [(if to-keys? (keyword Key) Key)
             (when Value (fromBase64 Value))]))))
 
-(defn put 
+(defn put
   ([path v]
    (put path v {}))
   ([path v ops]
@@ -97,21 +97,28 @@
     (start-watcher (recurse path) fun stop-ch ops)
     (Watcher. stop-ch))))
 
+(defn- mk-ops
+    [ops-1 ops-2]
+    (cond
+        (map? ops-1) [ops-1 ops-2]
+        (map? ops-2) [ops-2 ops-1]
+        (keyword? ops-1) [{} ops-1]
+        (keyword? ops-2) [{} ops-2]
+        :else [{} :edn]))
+
 (defn map->consul
-  ([kv-path m]
-   (map->consul kv-path m {}))
-  ([kv-path m ops]
-   (let [kv-path (tools/without-slash kv-path)]
-     (doseq [[k v] (tools/map->props m)]
-       (put (str kv-path "/" k) (str v) ops)))))
+  [kv-path m & [ops-1 ops-2]]
+   (let [kv-path (tools/without-slash kv-path)
+         [ops serializer] (mk-ops ops-1 ops-2)]
+     (doseq [[k v] (tools/map->props m serializer)]
+       (put (str kv-path "/" k) (str v) ops))))
 
 (defn consul->map
-  ([path]
-   (consul->map path {}))
-  ([path {:keys [offset] :as ops}]
+  [path & [ops-1 ops-2]]
+   (let [[{:keys [offset] :as ops} serializer] (mk-ops ops-1 ops-2)]
    (-> (partial get-all path
                         (merge ops {:keywordize? false}))
-       tools/props->map
+       (tools/props->map serializer)
        (get-in (tools/cpath->kpath offset)))))
 
 (defn copy

--- a/src/envoy/tools.clj
+++ b/src/envoy/tools.clj
@@ -20,7 +20,7 @@
                  (concat (map (partial link connect (key->x k))
                               (map->flat v key->x connect))
                          path)
-                 (or (vector? v) (seq? v)) (conj path
+                 (or (sequential? v)) (conj path
                                                  [(key->x k) (try
                                                                 (json/generate-string (vec v))
                                                                 (catch Throwable _ v))])
@@ -45,7 +45,7 @@
          (catch Throwable _
          ;;fallback to edn for compatibility
          (try
-           (let [parsed (edn/read-string v true)]
+           (let [parsed (edn/read-string v)]
              (if (symbol? parsed)
                v
                parsed))

--- a/src/envoy/tools.clj
+++ b/src/envoy/tools.clj
@@ -20,7 +20,7 @@
                  (concat (map (partial link connect (key->x k))
                               (map->flat v key->x connect))
                          path)
-                 (or (sequential? v)) (conj path
+                 (sequential? v) (conj path
                                                  [(key->x k) (try
                                                                 (json/generate-string (vec v))
                                                                 (catch Throwable _ v))])

--- a/src/envoy/tools.clj
+++ b/src/envoy/tools.clj
@@ -13,24 +13,43 @@
   (let [to (key->prop to)]
     [(str from connect to) value]))
 
-(defn- map->flat [m key->x connect]
+(defn- serialize
+    [v serializer]
+    (condp = serializer
+        :edn (str (vec v))
+        :json (json/generate-string (vec v))
+        (serialize v :edn)))
+
+(defn- map->flat [m key->x connect & [serializer]]
   (reduce-kv (fn [path k v]
                (cond
                  (map? v)
                  (concat (map (partial link connect (key->x k))
-                              (map->flat v key->x connect))
+                              (map->flat v key->x connect serializer))
                          path)
-                 (sequential? v) (conj path
-                                                 [(key->x k) (try
-                                                                (json/generate-string (vec v))
-                                                                (catch Throwable _ v))])
+                 (sequential? v) (conj path [(key->x k) (serialize v serializer)])
                  :else (conj path [(key->x k) v])))
              [] m))
 
-(defn map->props [m]
-  (map->flat m key->prop "/"))
+(defn map->props [m & [serializer]]
+  (map->flat m key->prop "/" serializer))
 
-(defn- str->value [v]
+(defn- deserialize
+  [v serializer]
+  (condp = serializer
+      :edn (try
+            (let [parsed (read-string v)]
+                (if (symbol? parsed)
+                    v
+                    parsed))
+            (catch Throwable _
+             v))
+      :json (try
+                (json/parse-string-strict v true)
+                (catch Throwable _ v))
+      (deserialize v :edn)))
+
+(defn- str->value [v & [deserializer]]
   "consul values are strings. str->value will convert:
   the numbers to longs, the alphanumeric values to strings, and will use Clojure reader for the rest
   in case reader can't read OR it reads a symbol, the value will be returned as is (a string)"
@@ -38,19 +57,7 @@
     (re-matches #"[0-9]+" v) (Long/parseLong v)
     (re-matches #"^(true|false)$" v) (Boolean/parseBoolean v)
     (re-matches #"\w+" v) v
-    :else
-    (try
-      ;;default json no symbol
-      (json/parse-string-strict v true)
-         (catch Throwable _
-         ;;fallback to edn for compatibility
-         (try
-           (let [parsed (edn/read-string v)]
-             (if (symbol? parsed)
-               v
-               parsed))
-          (catch Throwable _
-                v))))))
+    :else (deserialize v deserializer)))
 
 (defn- key->path [k level]
   (as-> k $
@@ -79,11 +86,11 @@
             (comp remove? second)
             m))))
 
-(defn props->map [read-from-consul]
+(defn props->map [read-from-consul & [deserializer]]
   (->> (for [[k v] (-> (read-from-consul)
                        remove-nils)]
           [(key->path k #"/")
-           (str->value v)])
+           (str->value v deserializer)])
        sys->map))
 
 ;; author of "deep-merge-with" is Chris Chouser: https://github.com/clojure/clojure-contrib/commit/19613025d233b5f445b1dd3460c4128f39218741


### PR DESCRIPTION
For interoperability, it is preferable to store vec/list/seq as json so that consul client from others languages can read data structure.

For compatibility, if json parsing/generating fail, it still falls back to edn writer/reader, so already stored edn structure are readable.

(I rewrite some stuff in our soft so that atomic update in structure which are in vec/seq are cached locally, then full vec/seq is push to envoy), but I still need to write into json because data stored are also used by python and go software.  