### PR TITLE
add "overwrite?" option into map->consul

### DIFF
--- a/src/envoy/core.clj
+++ b/src/envoy/core.clj
@@ -123,7 +123,7 @@
              (put (str kv-path "/" k) (str v) (dissoc ops :serializer :update)))
          ;;remove
          (doseq [[k v] (tools/map->props to-remove serializer)]
-            (when-not (get-in to-add (tools/cpath->kpath k) false)
+            (when (nil? (get-in to-add (tools/cpath->kpath k) nil))
                 @(http/delete (str kv-path "/" k))))))
 
 (defn map->consul

--- a/src/envoy/core.clj
+++ b/src/envoy/core.clj
@@ -113,7 +113,9 @@
           update-kv-path (str consul-url "kv")
           kpath (tools/cpath->kpath sub-path)
           stored-map (reduce (fn [acc [k v]]
-                               (merge acc (consul->map (str kv-path "/" (name k)) serializer)))
+                               (merge acc (consul->map
+                                            (str kv-path "/" (name k))
+                                            {:serializer serializer})))
                                {} m)
          ;;to update correctly seq we need to pre-serialize map
           [to-add to-remove _] (diff (tools/serialize-map m serializer)

--- a/src/envoy/core.clj
+++ b/src/envoy/core.clj
@@ -113,7 +113,7 @@
           update-kv-path (str consul-url "kv")
           kpath (tools/cpath->kpath sub-path)
           stored-map (reduce (fn [acc [k v]]
-                               (merge acc (consul->map (str kv-path "/" (name k)))))
+                               (merge acc (consul->map (str kv-path "/" (name k)) serializer)))
                                {} m)
          ;;to update correctly seq we need to pre-serialize map
           [to-add to-remove _] (diff (tools/serialize-map m serializer)

--- a/src/envoy/tools.clj
+++ b/src/envoy/tools.clj
@@ -139,6 +139,10 @@
       (str path "/")
       path)))
 
+(defn clean-slash
+    [path]
+    (s/join "/"(remove #{""} (s/split path #"/"))))
+
 (defn without-slash
   "removes slash from either ':first' or ':last' (default) position
    in case it is there"
@@ -146,10 +150,12 @@
    (without-slash path {}))
   ([path {:keys [slash]
           :or {slash :last}}]
-   (let [[find-slash no-slash] (case slash
+    (if-not (= :both slash)
+        (let [[find-slash no-slash] (case slash
                                  :last [last drop-last]
                                  :first [first rest]
                                  :not-first-or-last-might-need-to-implement)]
-     (if (= (find-slash path) \/)
-       (apply str (no-slash path))
-       path))))
+          (if (= (find-slash path) \/)
+            (apply str (no-slash path))
+            path))
+       (clean-slash path))))

--- a/src/envoy/tools.clj
+++ b/src/envoy/tools.clj
@@ -20,6 +20,15 @@
         :json (json/generate-string (vec v))
         (serialize v :edn)))
 
+(defn serialize-map
+    [m & [serializer]]
+    (reduce-kv (fn [acc k v]
+        (cond
+            (map? v) (assoc acc k (serialize-map v serializer))
+            (sequential? v) (assoc acc k (serialize v serializer))
+            :else (assoc acc k (str v))))
+        {} m))
+
 (defn- map->flat [m key->x connect & [serializer]]
   (reduce-kv (fn [path k v]
                (cond


### PR DESCRIPTION
Into map->consul, using clojure.data/diff, when update option is set true, only diff will be commit to consul. 

Fields present in consul and not in map will be removed.

This update operation is processed based on first level keys of the sent map so it's safe to use it even on the root of kv store.

When update option is set to false, it just pushes map like current behavior. 

I hesitate to name this option "sync" and name function "update-consul" "sync-consul". I also think to "diff-only" and map-diff->consul. It could/should be eventually renamed to something more clear. 

I actually hesitate to put this into my own software, but it could be useful there.