### PR TITLE
support explicit nil values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ tree:
 
 repl:
 	clojure -A:repl
+
+test:
+        clojure -X:test

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,6 @@ tree:
 repl:
 	clojure -A:repl
 
-test:
-        clojure -X:test
+tests:
+	clojure -X:test
+

--- a/deps.edn
+++ b/deps.edn
@@ -14,4 +14,9 @@
            :deploy {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
                     :main-opts ["-m" "deps-deploy.deps-deploy" "deploy" "target/envoy.jar"]}
            :install {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
-                     :main-opts ["-m" "deps-deploy.deps-deploy" "install" "target/envoy.jar"]}}}
+                     :main-opts ["-m" "deps-deploy.deps-deploy" "install" "target/envoy.jar"]}
+           :test {:extra-paths ["test"]
+                  :exec-fn     cognitect.test-runner.api/test
+                  :main-opts   ["-m" "cognitect.test-runner"] 
+                  :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                                org.clojure/test.check               {:mvn/version "RELEASE"}}}}}

--- a/test/envoy/tools_test.clj
+++ b/test/envoy/tools_test.clj
@@ -1,0 +1,25 @@
+(ns envoy.tools-test
+  (:require [envoy.tools :as tools]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest ^:allow-explicit-nils-values
+  allow-explicit-nil-values
+  (let [case1 "Remove nil values and include explicit nil values"]
+    (println case1)
+    (testing case1
+      (let [props {"a" nil "b" "I have value"}
+            mp    (tools/props->map (constantly props) :edn)]
+        (println "Props sent: " props)
+        (println "Processed result: " mp) 
+        (is (some? (:b mp))
+        (is (nil? (:a mp)))))
+  (let [case2 "Explicitly have nil values which are case-insensitive"]
+    (println case2)
+    (testing case2
+      (let [props {"a" "some-value" "b" "NIL" "c" "nil" "d" "Nil"}
+            mp    (tools/props->map (constantly props) :edn)]
+        (println "Props sent: " props)
+        (println "Processed result: " mp) 
+        (is (some? (:a mp))
+        (is (every? nil? (-> (select-keys mp #{:b :c :d})
+                              vals))))))))))


### PR DESCRIPTION
 ## Fixes done
* When CONSUL properties are explicitly set as `nil`, `envoy` **shouldn't remove them**, _instead must consider them as `nil`_

 ## Changelog
* Modified **Makefile** added **test**
* Modified **deps.edn** added _test coverage_
* Modified **envoy.tools**
  * **str->value** support `nil` values
  * **props->map** to include properties with explicitly set `nil` values
  * **include-explicit-nil** private function