### PR TITLE
Consul needs to be called without the trailing / before params

### DIFF
--- a/src/envoy/core.clj
+++ b/src/envoy/core.clj
@@ -82,7 +82,7 @@
    (get-all path {}))
   ([path {:keys [keywordize?] :as ops
           :or {keywordize? true}}]
-   (-> @(http/get (recurse (tools/with-slash path))
+   (-> @(http/get (recurse (tools/without-slash path))
                   (with-ops (dissoc ops :keywordize?)))
        (read-values keywordize?))))
 


### PR DESCRIPTION
This url fails `/v1/kv/my-path/?recurse`.  This succeeds. `/v1/kv/my-path?recurse`

This change should be backwards compatible because the URLs mean the same thing.

The consul documentations shows calling without the trailing slash. https://developer.hashicorp.com/consul/api-docs/config#sample-request-1