### PR TITLE
Support `consul/authorization` & avoid main-thread blocking with `chan`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>tolitius</groupId>
   <artifactId>envoy</artifactId>
-  <version>0.1.32</version>
+  <version>0.1.32-SNAPSHOT</version>
   <name>envoy</name>
   <description>a gentle touch of clojure to hashicorp's consul</description>
   <url>https://github.com/tolitius/envoy</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>tolitius</groupId>
   <artifactId>envoy</artifactId>
-  <version>0.1.31</version>
+  <version>0.1.32</version>
   <name>envoy</name>
   <description>a gentle touch of clojure to hashicorp's consul</description>
   <url>https://github.com/tolitius/envoy</url>

--- a/src/envoy/watcher.clj
+++ b/src/envoy/watcher.clj
@@ -1,0 +1,69 @@
+(ns envoy.watcher
+  (:require [clojure.data :refer [diff]]
+            [clojure.core.async :refer [go-loop >!! alt! chan close!]]
+            [envoy.core :as core]
+            [org.httpkit.client :as http]))
+
+(defn- index-of [resp]
+  (-> resp
+      :headers
+      :x-consul-index))
+
+(defn- read-index
+  ([path]
+   (read-index path {}))
+  ([path ops]
+  (-> (http/get path (core/with-ops ops))
+      index-of)))
+
+(defn- start-watcher
+  ([path fun stop?]
+   (start-watcher path fun stop? {}))
+  ([path fun stop? ops]
+   (let [ch (chan)
+         close-all-channels (fn []
+                              (close! ch)
+                              (close! stop?))]
+     (go-loop [index   nil
+               current (try
+                         (core/get-all path ops)
+                         (catch RuntimeException watch-error
+                           (-> (format "Error while watching %s: %s" path watch-error)
+                               prn)
+                           (close-all-channels)))]
+              (try
+                (http/get (core/recurse path)
+                          (merge (core/with-ops (merge ops
+                                                       {:index (or index (read-index path ops))}))
+                                 (core/with-auth ops))
+                          #(>!! ch %))
+                (catch Exception watch-error
+                  (-> (format "Error while watching %s: %s" path watch-error)
+                      prn)
+                  (close-all-channels)))
+              (alt!
+                stop? ([_]
+                       (prn "stopping" path "watcher"))
+                ch ([resp]
+                    (let [new-idx (index-of resp)
+                          new-vs (core/read-values resp)]
+                      (when (and index (not= new-idx index))               ;; first time there is no index
+                        (when-let [changes (first (diff new-vs current))]
+                          (fun changes)))
+                      (recur new-idx new-vs))))))))
+
+(defprotocol Stoppable
+  (stop [this]))
+
+(deftype Watcher [ch]
+  Stoppable
+  (stop [_]
+    (>!! ch :done)))
+
+(defn watch-path
+  ([path fun]
+   (watch-path path fun {:token (System/getenv "CONSUL_TOKEN")}))
+  ([path fun ops]
+  (let [stop-ch (chan)]
+    (start-watcher path fun stop-ch ops)
+    (Watcher. stop-ch))))

--- a/src/envoy/watcher.clj
+++ b/src/envoy/watcher.clj
@@ -28,7 +28,7 @@
                current (try
                          (core/get-all path ops)
                          (catch RuntimeException watch-error
-                           (-> (format "Error while watching %s: %s" path watch-error)
+                           (-> (format "[envoy watcher]: could not read latest changes from '%s' due to: %s" path watch-error)
                                prn)
                            (close-all-channels)))]
               (try
@@ -38,7 +38,7 @@
                                  (core/with-auth ops))
                           #(>!! ch %))
                 (catch Exception watch-error
-                  (-> (format "Error while watching %s: %s" path watch-error)
+                  (-> (format "[envoy watcher]: could not read latest changes from '%s' due to: %s" path watch-error)
                       prn)
                   (close-all-channels)))
               (alt!


### PR DESCRIPTION
 ## preface
Whilst working with `envoy.core/watch-path` that allows us to listen for new changes and on every changes ocurring in `consul/path` found the scenario
  1. `consul/authorization` failing because of missing `headers->authorization`
  2. `go` and `alt!` keep listening on channels in case of `RuntimeException` causing _blocking main thread_ and failing during `(envoy.core/stop watcher)` Fixing them

 ## fixes done
* Bumping the version
* Adding `headers` within `wiht-ops` if `token` missing throwing `RuntimeException`
* Closing all `channel` incase of `RuntimeException` and closing within `try/catch` block

 ## modified
* Modified **pom.xml**
  * Bumping `version`
* Modified **src/envoy/core.clj**
  * Modified **with-ops** Using `token` and throwing `RuntimeException` incase of missing `token`
  * Modified **start-watcher**
    * Enclosing within `try/catch`
    * `close-all-channels` variable which does what is says closing `ch` and `stop?`

 ## unit testing
```bash
➜  envoy git:(master) ✗ make repl
clojure -A:repl
(Clojure 1.11.1
user=> require 'envoy.core)
(nil
user=> def x (envoy.core/watch-path "https://local-consul:8500/v1/kv/planet/earth" println)))
Syntax error reading source at (REPL:2:118).
Unmatched delimiter: )
user=> "Error while watching http://local-consul:8500/v1/kv/planet/earth: java.lang.RuntimeException: could not find path in consul{:path \"http://local-consul:8500/v1/kv/planet/earth?recurse\"}"
"stopping" "http://local-consul:8500/v1/kv/planet/earth" "watcher"
(envoy.core/stop x)
false
user=> (def x' (envoy.core "http://local-consul:8500/v1/kv/planet/mars" #(println "watching: " %)))
Syntax error (ClassNotFoundException) compiling at (REPL:1:9).
envoy.core
user=> (def x' (envoy.core/watch-path "http://local-consul:8500/v1/kv/planet/mars" #(println "watching: " %)))
user=> "Error while watching http://local-consul:8500/v1/kv/planet/mars: java.lang.RuntimeException: could not find path in consul{:path \"http://local-consul:8500/v1/kv/planet/mars?recurse\"}"
Exception in thread "async-dispatch-2" java.lang.RuntimeException: failed to read from consul{:path nil, :error nil, :http-status nil}
        at envoy.core$read_values.invokeStatic(core.clj:41)
        at envoy.core$read_values.invoke(core.clj:34)
        at envoy.core$read_values.invokeStatic(core.clj:36)
        at envoy.core$read_values.invoke(core.clj:34)
        at envoy.core$start_watcher$fn__10625$state_machine__7306__auto____10638$fn__10640.invoke(core.clj:100)
        at envoy.core$start_watcher$fn__10625$state_machine__7306__auto____10638.invoke(core.clj:100)
        at clojure.core.async.impl.ioc_macros$run_state_machine.invokeStatic(ioc_macros.clj:972)
        at clojure.core.async.impl.ioc_macros$run_state_machine.invoke(ioc_macros.clj:971)
        at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invokeStatic(ioc_macros.clj:976)
        at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke(ioc_macros.clj:974)
        at envoy.core$start_watcher$fn__10625.invoke(core.clj:100)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at clojure.core.async.impl.concurrent$counted_thread_factory$reify__1078$fn__1079.invoke(concurrent.clj:29)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.base/java.lang.Thread.run(Thread.java:1583)
(envoy.core/stop x')
false
user=> (def x'' (envoy.core/watch-path "http://local-consul:8500/v1/kv/planet/mars" #(println "watching: " %)))
user=> watching:  #:planet{:mars {"40d5608c09fb04c77a8250ef8704e94b" "ooohhh i am awesome"}
(envoy.core/stop x'')
true
"user=> stopping" "http://local-consul:8500/v1/kv/planet/mars" "watcher"
```