### PR TITLE
Handle the possible issues with `envoy.watcher`

### DIFF
--- a/src/envoy/core.clj
+++ b/src/envoy/core.clj
@@ -24,9 +24,13 @@
    (read-values resp true))
   ([{:keys [body error status opts] :as resp} to-keys?]
    (if (or error (not= status 200))
-     (if (= 404 status)
-       (throw (RuntimeException. (str "could not find path in consul" {:path (:url opts)})))
-       (throw (RuntimeException. (str "failed to read from consul" {:path (:url opts)
+     (cond
+       (= 404 status) (throw (RuntimeException. (str "could not find path in consul" {:path (:url opts)})))
+       (nil? status)  (throw (ex-info "Connection timed out" {:error error
+                                                              :path (:url opts)
+                                                              :cause :timeout}
+                                                             error))
+       :else          (throw (RuntimeException. (str "failed to read from consul" {:path (:url opts)
                                                                     :error error
                                                                     :http-status status}))))
      (into {}


### PR DESCRIPTION
 ## preface
Recently with `envoy.watcher` to support `consul` watching applied on real-time we came across new possible scenarios which requires to be handled, they are:
1. handle `consul` `Timeout` error -> with continous polling
2. when trying to push data to `channel` make sure the `channel` are _open and active_ to avoid blocking main thread.
3. Return `ExceptionInfo` instead of `RuntimeException` to handle `clojure-data` and interpret the actual exception

 ## fixes done
* Returning `clojure.lang.ExceptionInfo` for `timeout` issue instead of `RuntimeException`
* pushing to `channel` _iff_ the `channel` is _open / active_
* making use of `put!` to have `callback` after `channel` is being responsive and not closed
* Refactoring changes

 ## changelog
* Modified **envoy.core**
  * Using `clojure.lang.ExceptionInfo` for **read-values**
* Modified **envoy.watcher**
  * refactoring duplicate piece of code
  * added **data->channel** which checks if the `channel` is opened or not then procceds with respective action