### PR TITLE
Fix read-values :else branch not throwing an exception

### DIFF
--- a/src/envoy/core.cljc
+++ b/src/envoy/core.cljc
@@ -34,10 +34,10 @@
                                                :cause :timeout}
                        error))
        :else
-       (ex-info "failed to read from consul"
-                {:path (:url opts)
-                 :http-status status}
-                error))
+       (throw (ex-info (str "failed to read from consul" (when body (str " (" body ")")))
+                       {:path (:url opts)
+                        :http-status status}
+                       error)))
      (into {}
            (for [{:keys [Key Value]} (json/parse-string body true)]
              [(if to-keys? (keyword Key) Key)


### PR DESCRIPTION
The `:else` in `envoy.core/read-values` was returning an `ex-info` rather than throwing it. This patch fixes that.