### PR TITLE
adding bearer auth to support consul version >= v1.17

### DIFF
--- a/src/envoy/session.cljc
+++ b/src/envoy/session.cljc
@@ -13,7 +13,7 @@
    (hget path {}))
   ([path ops]
    (let [{:keys [body error status] :as resp} @(http/get path
-                                                         (tools/with-ops ops))]
+                                                         (tools/with-bearer-auth ops))]
      (if (or error (not= status 200))
        (throw (ex-info (str "could not GET from consul due to: " (error-message resp))
                        (tools/dissoc-in resp [:opts :query-params :token])
@@ -26,7 +26,7 @@
    (hput path v {}))
   ([path v ops]
    (let [{:keys [error status] :as resp} @(http/put path (merge {:body v}
-                                                                (tools/with-ops ops)))]
+                                                                (tools/with-bearer-auth ops)))]
      (if (or error (not= 200 status))
        (throw (ex-info (str "could not PUT to consul due to: " (error-message resp))
                        (tools/dissoc-in resp [:opts :query-params :token])

--- a/src/envoy/tools.cljc
+++ b/src/envoy/tools.cljc
@@ -241,6 +241,10 @@
   (when token
     {:headers {"authorization" token}}))
 
+(defn with-bearer-auth [{:keys [token]}]
+  (when token
+    {:headers {"authorization" (str "Bearer " token)}}))
+
 (defn complete-key-path [path offset k]
   (cond-> path
     offset (concat-with-slash offset)


### PR DESCRIPTION
problem:
right now we are passing consul token as query params, which will be removed from consul v1.17
```
This request used the token query parameter which is deprecated and will be removed in Consul 1.17: logUrl="/v1/kv/multipass/session-locks/permiso/open-permits-materialized-view-refresh/.lock?acquire=a63acda7-e605-f04f-e111-228fb5d76a70&token=<hidden>"
```

fix:
based on the consul http api [doc](https://developer.hashicorp.com/consul/api-docs/api-structure#authentication) instead we can pass consul token as auth header like Bearer token
